### PR TITLE
Remove unused dodgy OpenGameFileW variant

### DIFF
--- a/base/utils/FindFile.cpp
+++ b/base/utils/FindFile.cpp
@@ -703,27 +703,6 @@ bool OpenGameFileR(std::ifstream& f, const std::string& path, std::ios_base::ope
 	return false;
 }
 
-std::ofstream && OpenGameFileW(const std::string& path, const std::ios_base::openmode mode)
-{
-    std::ofstream f;
-
-    if(path.size() == 0)
-        return std::move(f);
-
-    std::string fullfn = GetWriteFullFileName(path, true);
-    if(fullfn.size() != 0)
-    {
-        try
-        {
-            f.open(Utf8ToSystemNative(fullfn).c_str(), mode);
-            return std::move(f);
-        }
-        catch(...) {}
-    }
-
-    return std::move(f);
-}
-
 
 bool OpenGameFileW(std::ofstream& f, const std::string& path, std::ios_base::openmode mode)
 {

--- a/base/utils/FindFile.h
+++ b/base/utils/FindFile.h
@@ -193,9 +193,6 @@ FILE*	OpenAbsFile(const std::string& path, const char *mode);
 bool OpenGameFileR(std::ifstream& f, const std::string& path, std::ios_base::openmode mode = std::ios_base::in);
 bool OpenGameFileW(std::ofstream& f, const std::string& path, std::ios_base::openmode mode = std::ios_base::out);
 
-// Versions which return the stream directly
-std::ofstream && OpenGameFileW(const std::string& path, const std::ios_base::openmode mode);
-
 
 std::string GetFileContents(const std::string& path, bool absolute = false);
 std::string ExtractDirectory(const std::string& path);


### PR DESCRIPTION
This was giving compiler warnings due to returning a stack variable.